### PR TITLE
バンドル単体のテスト環境を更新

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ before_script:
 
 php:
   - 5.6
+  - 7.0
+  - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ before_script:
     - composer install --dev --prefer-source
 
 php:
-  - 5.4
-  - 5.5
   - 5.6

--- a/Tests/Plugin/WebPayPluginTest.php
+++ b/Tests/Plugin/WebPayPluginTest.php
@@ -72,7 +72,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveAndDeposit()
     {
-        $transaction = $this->getMock('JMS\Payment\CoreBundle\Model\FinancialTransactionInterface');
+        $transaction = $this->createMock('JMS\Payment\CoreBundle\Model\FinancialTransactionInterface');
 
         $transaction
             ->expects($this->once())
@@ -82,7 +82,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
         $transaction
             ->expects($this->once())
             ->method('getPayment')
-            ->will($this->returnValue($payment = $this->getMock('JMS\Payment\CoreBundle\Model\PaymentInterface')));
+            ->will($this->returnValue($payment = $this->createMock('JMS\Payment\CoreBundle\Model\PaymentInterface')));
 
         $transaction
             ->expects($this->once())
@@ -168,7 +168,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     private function getPaymentInstruction()
     {
-        return $this->getMock('JMS\Payment\CoreBundle\Model\PaymentInstructionInterface');
+        return $this->createMock('JMS\Payment\CoreBundle\Model\PaymentInstructionInterface');
     }
 
     /**
@@ -176,6 +176,6 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     private function getExtendedData()
     {
-        return $this->getMock('JMS\Payment\CoreBundle\Model\ExtendedDataInterface');
+        return $this->createMock('JMS\Payment\CoreBundle\Model\ExtendedDataInterface');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "branch-alias": {
            "dev-master": "1.0.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0"
     }
 }


### PR DESCRIPTION
※現在使われておらず、ほぼメンテしていませんが、Lisketのdeprecation警告を消すために必要な範囲で修正を行っています。

- phpunitをcomposerの依存に入れて使う
- 古いPHPバージョンでテストしない
- 新しいPHPバージョンでテストする