### PR TITLE
Symfony2.8でdeprecation警告が出る部分の修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ before_script:
     - composer install --dev --prefer-source
 
 php:
-  - 5.4
-  - 5.5
   - 5.6

--- a/Form/Type/WebPayType.php
+++ b/Form/Type/WebPayType.php
@@ -3,6 +3,7 @@
 namespace Quartet\Payment\WebPayBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class WebPayType extends AbstractType
@@ -13,11 +14,11 @@ class WebPayType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('number', 'text')
-            ->add('exp_month', 'text')
-            ->add('exp_year', 'text')
-            ->add('cvc', 'text')
-            ->add('name', 'text')
+            ->add('number', TextType::class)
+            ->add('exp_month', TextType::class)
+            ->add('exp_year', TextType::class)
+            ->add('cvc', TextType::class)
+            ->add('name', TextType::class)
         ;
     }
 

--- a/Form/Type/WebPayType.php
+++ b/Form/Type/WebPayType.php
@@ -24,7 +24,7 @@ class WebPayType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'quartet_payment_webpay';
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
   quartet_payment_webpay.plugin.webpay:
     class: Quartet\Payment\WebPayBundle\Plugin\WebPayPlugin
     arguments:
-      - @quartet_webpay.charges
+      - "@quartet_webpay.charges"
     tags:
       - { name: payment.plugin }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,5 +9,5 @@ services:
   quartet_payment_webpay.form_type.credit_card:
     class: Quartet\Payment\WebPayBundle\Form\Type\WebPayType
     tags:
-      - { name: form.type, alias: quartet_payment_webpay }
+      - { name: form.type }
       - { name: payment.method_form_type }

--- a/Tests/Plugin/WebPayPluginTest.php
+++ b/Tests/Plugin/WebPayPluginTest.php
@@ -72,7 +72,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     public function testApproveAndDeposit()
     {
-        $transaction = $this->getMock('JMS\Payment\CoreBundle\Model\FinancialTransactionInterface');
+        $transaction = $this->createMock('JMS\Payment\CoreBundle\Model\FinancialTransactionInterface');
 
         $transaction
             ->expects($this->once())
@@ -82,7 +82,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
         $transaction
             ->expects($this->once())
             ->method('getPayment')
-            ->will($this->returnValue($payment = $this->getMock('JMS\Payment\CoreBundle\Model\PaymentInterface')));
+            ->will($this->returnValue($payment = $this->createMock('JMS\Payment\CoreBundle\Model\PaymentInterface')));
 
         $transaction
             ->expects($this->once())
@@ -168,7 +168,7 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     private function getPaymentInstruction()
     {
-        return $this->getMock('JMS\Payment\CoreBundle\Model\PaymentInstructionInterface');
+        return $this->createMock('JMS\Payment\CoreBundle\Model\PaymentInstructionInterface');
     }
 
     /**
@@ -176,6 +176,6 @@ class WebPayPluginTest extends \PHPUnit_Framework_TestCase
      */
     private function getExtendedData()
     {
-        return $this->getMock('JMS\Payment\CoreBundle\Model\ExtendedDataInterface');
+        return $this->createMock('JMS\Payment\CoreBundle\Model\ExtendedDataInterface');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
         "branch-alias": {
            "dev-master": "1.0.x-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0"
     }
 }


### PR DESCRIPTION
※現在使われておらず、ほぼメンテしていませんが、Lisketのdeprecation警告を消すために必要な範囲で修正を行っています。

- yml上の参照を引用符で囲む
- Formのalias,getName()→getBlockPrefix()
- Formの$builder->add()にエイリアスでなくFQCNを渡す
