### PR TITLE
JMSPaymentBundleでSymfonyのカーネルが2.xの場合はform.typeのalias指定が必須だったので修正

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,5 +9,5 @@ services:
   quartet_payment_webpay.form_type.credit_card:
     class: Quartet\Payment\WebPayBundle\Form\Type\WebPayType
     tags:
-      - { name: form.type }
+      - { name: form.type, alias: quartet_payment_webpay }
       - { name: payment.method_form_type }


### PR DESCRIPTION
#2 で不要として削除したaliasがJMSPaymentBundleで必須だったので修正しました。